### PR TITLE
Add Roles decorator

### DIFF
--- a/backend/src/modules/auth/decorators/roles.decorator.ts
+++ b/backend/src/modules/auth/decorators/roles.decorator.ts
@@ -1,0 +1,4 @@
+// roles.decorator.ts
+import { SetMetadata } from '@nestjs/common';
+
+export const Roles = (...roles: string[]) => SetMetadata('roles', roles);


### PR DESCRIPTION
## Summary
- implement `Roles` decorator that stores allowed roles in metadata

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684206461f18832bbdc4a075c8d8e916