### PR TITLE
Add Users module with CRUD endpoints

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import configuration from './config/configuration';
 // Módulos principales
 // Importamos solo el CoreModule por ahora
 import { CoreModule } from './modules/core/core.module';
+import { UsersModule } from './modules/users/users.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { CoreModule } from './modules/core/core.module';
 
     // Módulos de la aplicación
     CoreModule,
+    UsersModule,
     // Los demás módulos se agregarán a medida que se implementen
   ],
   providers: [],

--- a/backend/src/modules/users/controllers/users.controller.ts
+++ b/backend/src/modules/users/controllers/users.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, UseGuards } from '@nestjs/common';
+import { UsersService } from '../services/users.service';
+import { CreateUserDto } from '../dto/create-user.dto';
+import { UpdateUserDto } from '../dto/update-user.dto';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger';
+
+@ApiTags('Usuarios')
+@Controller('users')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@ApiBearerAuth()
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post()
+  @Roles('admin')
+  @ApiOperation({ summary: 'Crear nuevo usuario' })
+  @ApiResponse({ status: 201, description: 'Usuario creado exitosamente' })
+  create(@Body() createUserDto: CreateUserDto) {
+    return this.usersService.create(createUserDto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Obtener todos los usuarios' })
+  findAll() {
+    return this.usersService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Obtener usuario por ID' })
+  @ApiResponse({ status: 200, description: 'Usuario obtenido exitosamente' })
+  @ApiResponse({ status: 404, description: 'Usuario no encontrado' })
+  findOne(@Param('id') id: string) {
+    return this.usersService.findOne(id);
+  }
+
+  @Patch(':id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Actualizar usuario' })
+  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+    return this.usersService.update(id, updateUserDto);
+  }
+
+  @Delete(':id')
+  @Roles('admin')
+  @ApiOperation({ summary: 'Eliminar usuario' })
+  remove(@Param('id') id: string) {
+    return this.usersService.remove(id);
+  }
+}

--- a/backend/src/modules/users/dto/create-user.dto.ts
+++ b/backend/src/modules/users/dto/create-user.dto.ts
@@ -1,0 +1,8 @@
+export class CreateUserDto {
+  readonly username: string;
+  readonly email: string;
+  readonly password: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly isAdmin?: boolean;
+}

--- a/backend/src/modules/users/dto/update-user.dto.ts
+++ b/backend/src/modules/users/dto/update-user.dto.ts
@@ -1,0 +1,9 @@
+export class UpdateUserDto {
+  readonly username?: string;
+  readonly email?: string;
+  readonly password?: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly isActive?: boolean;
+  readonly isAdmin?: boolean;
+}

--- a/backend/src/modules/users/entities/user.entity.ts
+++ b/backend/src/modules/users/entities/user.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('users', { schema: 'core' })
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 50, unique: true })
+  username: string;
+
+  @Column({ length: 100, unique: true })
+  email: string;
+
+  @Column({ name: 'password_hash', length: 100 })
+  passwordHash: string;
+
+  @Column({ name: 'first_name', length: 50, nullable: true })
+  firstName?: string;
+
+  @Column({ name: 'last_name', length: 50, nullable: true })
+  lastName?: string;
+
+  @Column({ name: 'is_active', default: true })
+  isActive: boolean;
+
+  @Column({ name: 'is_admin', default: false })
+  isAdmin: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/users/services/users.service.ts
+++ b/backend/src/modules/users/services/users.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../entities/user.entity';
+import { CreateUserDto } from '../dto/create-user.dto';
+import { UpdateUserDto } from '../dto/update-user.dto';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  create(dto: CreateUserDto) {
+    const user = this.usersRepository.create({
+      username: dto.username,
+      email: dto.email,
+      passwordHash: dto.password,
+      firstName: dto.firstName,
+      lastName: dto.lastName,
+      isAdmin: dto.isAdmin ?? false,
+    });
+    return this.usersRepository.save(user);
+  }
+
+  findAll() {
+    return this.usersRepository.find();
+  }
+
+  findOne(id: string) {
+    return this.usersRepository.findOne({ where: { id } });
+  }
+
+  async update(id: string, dto: UpdateUserDto) {
+    if (dto.password) {
+      await this.usersRepository.update(id, {
+        ...dto,
+        passwordHash: dto.password,
+      });
+    } else {
+      await this.usersRepository.update(id, dto as any);
+    }
+    return this.findOne(id);
+  }
+
+  async remove(id: string) {
+    const user = await this.findOne(id);
+    await this.usersRepository.delete(id);
+    return user;
+  }
+}

--- a/backend/src/modules/users/users.module.ts
+++ b/backend/src/modules/users/users.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { UsersService } from './services/users.service';
+import { UsersController } from './controllers/users.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}


### PR DESCRIPTION
## Summary
- add UsersModule with entity, DTOs, service and controller
- register UsersModule in AppModule

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420be4b1f0832ba35a620d508d2199