### PR TITLE
Add audit logging

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,10 +2,15 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import configuration from './config/configuration';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+
+// Interceptor
+import { AuditInterceptor } from './common/interceptors/audit.interceptor';
 
 // Módulos principales
 // Importamos solo el CoreModule por ahora
 import { CoreModule } from './modules/core/core.module';
+import { AuditModule } from './modules/audit/audit.module';
 
 @Module({
   imports: [
@@ -32,8 +37,14 @@ import { CoreModule } from './modules/core/core.module';
 
     // Módulos de la aplicación
     CoreModule,
+    AuditModule,
     // Los demás módulos se agregarán a medida que se implementen
   ],
-  providers: [],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: AuditInterceptor,
+    },
+  ],
 })
 export class AppModule {}

--- a/backend/src/common/interceptors/audit.interceptor.ts
+++ b/backend/src/common/interceptors/audit.interceptor.ts
@@ -1,0 +1,41 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { AuditService } from '../../modules/audit/services/audit.service';
+
+@Injectable()
+export class AuditInterceptor implements NestInterceptor {
+  constructor(private readonly auditService: AuditService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const request = context.switchToHttp().getRequest();
+    const method = request.method;
+    const user = request.user;
+    const ip = request.ip;
+    const userAgent = request.headers['user-agent'];
+    const entityId = request.params?.id ?? null;
+    const entityType = context.getClass().name.replace('Controller', '');
+
+    return next.handle().pipe(
+      tap(async (responseData) => {
+        let action: string | null = null;
+        if (['POST'].includes(method)) action = 'CREATE';
+        if (['PUT', 'PATCH'].includes(method)) action = 'UPDATE';
+        if (method === 'DELETE') action = 'DELETE';
+        if (request.route?.path === 'login' || request.url.includes('login')) action = 'LOGIN';
+
+        if (action) {
+          await this.auditService.log({
+            userId: user?.id,
+            entityType,
+            entityId: entityId || (responseData && responseData.id),
+            action,
+            newState: responseData,
+            ipAddress: ip,
+            userAgent,
+          });
+        }
+      }),
+    );
+  }
+}

--- a/backend/src/modules/audit/audit.module.ts
+++ b/backend/src/modules/audit/audit.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuditLog } from './entities/audit-log.entity';
+import { AuditService } from './services/audit.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AuditLog])],
+  providers: [AuditService],
+  exports: [AuditService],
+})
+export class AuditModule {}

--- a/backend/src/modules/audit/entities/audit-log.entity.ts
+++ b/backend/src/modules/audit/entities/audit-log.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('audit_logs', { schema: 'core' })
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id', type: 'uuid', nullable: true })
+  userId: string | null;
+
+  @Column({ name: 'entity_type', length: 100 })
+  entityType: string;
+
+  @Column({ name: 'entity_id', type: 'uuid' })
+  entityId: string;
+
+  @Column({ length: 20 })
+  action: string;
+
+  @Column({ name: 'previous_state', type: 'jsonb', nullable: true })
+  previousState: any;
+
+  @Column({ name: 'new_state', type: 'jsonb', nullable: true })
+  newState: any;
+
+  @Column({ name: 'ip_address', length: 45, nullable: true })
+  ipAddress: string | null;
+
+  @Column({ name: 'user_agent', type: 'text', nullable: true })
+  userAgent: string | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp with time zone' })
+  createdAt: Date;
+}

--- a/backend/src/modules/audit/services/audit.service.ts
+++ b/backend/src/modules/audit/services/audit.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AuditLog } from '../entities/audit-log.entity';
+
+export interface AuditLogPayload {
+  userId?: string | null;
+  entityType: string;
+  entityId: string;
+  action: string;
+  previousState?: any;
+  newState?: any;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+}
+
+@Injectable()
+export class AuditService {
+  constructor(
+    @InjectRepository(AuditLog)
+    private readonly repo: Repository<AuditLog>,
+  ) {}
+
+  async log(payload: AuditLogPayload): Promise<void> {
+    const log = this.repo.create({
+      userId: payload.userId ?? null,
+      entityType: payload.entityType,
+      entityId: payload.entityId,
+      action: payload.action,
+      previousState: payload.previousState ?? null,
+      newState: payload.newState ?? null,
+      ipAddress: payload.ipAddress ?? null,
+      userAgent: payload.userAgent ?? null,
+    });
+    await this.repo.save(log);
+  }
+}


### PR DESCRIPTION
## Summary
- add `audit` module with `AuditLog` entity
- create `AuditService` to record logs to the `core.audit_logs` table
- implement a global `AuditInterceptor` hooked via `APP_INTERCEPTOR`
- register `AuditModule` and the interceptor in `AppModule`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420beda808832b927e0aefae556c1b