### PR TITLE
Implement stores and maintenance pages

### DIFF
--- a/frontend/edi-frontend/src/boot/axios.ts
+++ b/frontend/edi-frontend/src/boot/axios.ts
@@ -11,4 +11,6 @@ export default boot(({ app }: { app: App }) => {
   app.config.globalProperties.$api = api;
 });
 
+export { api };
+
 

--- a/frontend/edi-frontend/src/pages/Dashboard.vue
+++ b/frontend/edi-frontend/src/pages/Dashboard.vue
@@ -1,0 +1,36 @@
+<template>
+  <q-page class="q-pa-md">
+    <div class="row q-col-gutter-md">
+      <q-card class="col-12 col-sm-4">
+        <q-card-section>
+          <div class="text-h6">Empresas</div>
+          <div class="text-h4">{{ companiesCount }}</div>
+        </q-card-section>
+      </q-card>
+      <q-card class="col-12 col-sm-4">
+        <q-card-section>
+          <div class="text-h6">Sucursales</div>
+          <div class="text-h4">{{ branchesCount }}</div>
+        </q-card-section>
+      </q-card>
+    </div>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { api } from 'boot/axios';
+
+const companiesCount = ref(0);
+const branchesCount = ref(0);
+
+async function loadStats() {
+  const companies = await api.get('/companies');
+  companiesCount.value = companies.data.length;
+
+  const branches = await api.get('/branches');
+  branchesCount.value = branches.data.length;
+}
+
+onMounted(loadStats);
+</script>

--- a/frontend/edi-frontend/src/pages/RolesPage.vue
+++ b/frontend/edi-frontend/src/pages/RolesPage.vue
@@ -1,0 +1,40 @@
+<template>
+  <q-page class="q-pa-md">
+    <div class="q-mb-md">
+      <q-input v-model="newRole.name" label="Nombre" class="q-mb-sm" />
+      <q-input v-model="newRole.description" label="Descripción" class="q-mb-sm" />
+      <q-btn label="Guardar" color="primary" @click="saveRole" />
+    </div>
+
+    <q-list bordered>
+      <q-item v-for="role in rolesStore.roles" :key="role.id">
+        <q-item-section>
+          <q-item-label>{{ role.name }}</q-item-label>
+          <q-item-label caption>{{ role.description }}</q-item-label>
+        </q-item-section>
+        <q-item-section side>
+          <q-btn dense flat icon="delete" @click="rolesStore.deleteRole(role.id)" />
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRolesStore } from 'stores/roles';
+
+const rolesStore = useRolesStore();
+const newRole = ref({ name: '', description: '' });
+
+onMounted(() => {
+  rolesStore.fetchRoles();
+});
+
+async function saveRole() {
+  if (newRole.value.name) {
+    await rolesStore.createRole(newRole.value);
+    newRole.value = { name: '', description: '' };
+  }
+}
+</script>

--- a/frontend/edi-frontend/src/pages/UsersPage.vue
+++ b/frontend/edi-frontend/src/pages/UsersPage.vue
@@ -1,0 +1,40 @@
+<template>
+  <q-page class="q-pa-md">
+    <div class="q-mb-md">
+      <q-input v-model="newUser.username" label="Usuario" class="q-mb-sm" />
+      <q-input v-model="newUser.email" label="Email" class="q-mb-sm" />
+      <q-btn label="Guardar" color="primary" @click="saveUser" />
+    </div>
+
+    <q-list bordered>
+      <q-item v-for="user in usersStore.users" :key="user.id">
+        <q-item-section>
+          <q-item-label>{{ user.username }}</q-item-label>
+          <q-item-label caption>{{ user.email }}</q-item-label>
+        </q-item-section>
+        <q-item-section side>
+          <q-btn dense flat icon="delete" @click="usersStore.deleteUser(user.id)" />
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useUsersStore } from 'stores/users';
+
+const usersStore = useUsersStore();
+const newUser = ref({ username: '', email: '' });
+
+onMounted(() => {
+  usersStore.fetchUsers();
+});
+
+async function saveUser() {
+  if (newUser.value.username && newUser.value.email) {
+    await usersStore.createUser(newUser.value);
+    newUser.value = { username: '', email: '' };
+  }
+}
+</script>

--- a/frontend/edi-frontend/src/router/routes.ts
+++ b/frontend/edi-frontend/src/router/routes.ts
@@ -8,7 +8,8 @@ const routes: RouteRecordRaw[] = [
       { path: '', component: () => import('pages/IndexPage.vue') },
       { path: 'dashboard', component: () => import('pages/Dashboard.vue'), meta: { requiresAuth: true } },
       { path: 'login', component: () => import('pages/Login.vue') },
-      // otras rutas
+      { path: 'users', component: () => import('pages/UsersPage.vue'), meta: { requiresAuth: true } },
+      { path: 'roles', component: () => import('pages/RolesPage.vue'), meta: { requiresAuth: true } },
     ],
   },
 

--- a/frontend/edi-frontend/src/stores/roles.ts
+++ b/frontend/edi-frontend/src/stores/roles.ts
@@ -1,0 +1,41 @@
+import { defineStore } from 'pinia';
+import { api } from 'boot/axios';
+
+export interface Role {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export const useRolesStore = defineStore('roles', {
+  state: () => ({
+    roles: [] as Role[],
+    loading: false
+  }),
+  actions: {
+    async fetchRoles() {
+      this.loading = true;
+      try {
+        const res = await api.get('/roles');
+        this.roles = res.data;
+      } finally {
+        this.loading = false;
+      }
+    },
+    async createRole(data: Partial<Role>) {
+      const res = await api.post('/roles', data);
+      await this.fetchRoles();
+      return res.data;
+    },
+    async updateRole(id: string, data: Partial<Role>) {
+      const res = await api.put(`/roles/${id}`, data);
+      await this.fetchRoles();
+      return res.data;
+    },
+    async deleteRole(id: string) {
+      const res = await api.delete(`/roles/${id}`);
+      await this.fetchRoles();
+      return res.data;
+    }
+  }
+});

--- a/frontend/edi-frontend/src/stores/users.ts
+++ b/frontend/edi-frontend/src/stores/users.ts
@@ -1,0 +1,41 @@
+import { defineStore } from 'pinia';
+import { api } from 'boot/axios';
+
+export interface User {
+  id: string;
+  username: string;
+  email: string;
+}
+
+export const useUsersStore = defineStore('users', {
+  state: () => ({
+    users: [] as User[],
+    loading: false
+  }),
+  actions: {
+    async fetchUsers() {
+      this.loading = true;
+      try {
+        const res = await api.get('/users');
+        this.users = res.data;
+      } finally {
+        this.loading = false;
+      }
+    },
+    async createUser(data: Partial<User>) {
+      const res = await api.post('/users', data);
+      await this.fetchUsers();
+      return res.data;
+    },
+    async updateUser(id: string, data: Partial<User>) {
+      const res = await api.put(`/users/${id}`, data);
+      await this.fetchUsers();
+      return res.data;
+    },
+    async deleteUser(id: string) {
+      const res = await api.delete(`/users/${id}`);
+      await this.fetchUsers();
+      return res.data;
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- expose axios API instance
- add Pinia stores for roles and users
- add dashboard page and role/user maintenance pages
- wire new pages in router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68420bf5e0d0832bb23dfe8b284b674c