### PR TITLE
Add sales and inventory modules

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,8 @@
     "rxjs": "^7.2.0",
     "send": "^0.19.1",
     "serve-static": "^1.16.2",
-    "typeorm": "^0.3.24"
+    "typeorm": "^0.3.24",
+    "pdfmake": "^0.2.7"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.7",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,8 @@ import configuration from './config/configuration';
 // Módulos principales
 // Importamos solo el CoreModule por ahora
 import { CoreModule } from './modules/core/core.module';
+import { InventoryModule } from './modules/inventory/inventory.module';
+import { SalesModule } from './modules/sales/sales.module';
 
 @Module({
   imports: [
@@ -32,7 +34,8 @@ import { CoreModule } from './modules/core/core.module';
 
     // Módulos de la aplicación
     CoreModule,
-    // Los demás módulos se agregarán a medida que se implementen
+    InventoryModule,
+    SalesModule,
   ],
   providers: [],
 })

--- a/backend/src/modules/inventory/entities/product-stock.entity.ts
+++ b/backend/src/modules/inventory/entities/product-stock.entity.ts
@@ -1,0 +1,15 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Product } from './product.entity';
+
+@Entity('product_stock', { schema: 'inventory' })
+export class ProductStock {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Product)
+  @JoinColumn({ name: 'product_id' })
+  product: Product;
+
+  @Column('decimal', { precision: 19, scale: 4, default: 0 })
+  quantityOnHand: number;
+}

--- a/backend/src/modules/inventory/entities/product.entity.ts
+++ b/backend/src/modules/inventory/entities/product.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('products', { schema: 'inventory' })
+export class Product {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 20 })
+  code: string;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column('decimal', { precision: 19, scale: 4, nullable: true })
+  salesPrice: number | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/inventory/inventory.module.ts
+++ b/backend/src/modules/inventory/inventory.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Product } from './entities/product.entity';
+import { ProductStock } from './entities/product-stock.entity';
+import { InventoryService } from './services/inventory.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Product, ProductStock])],
+  providers: [InventoryService],
+  exports: [InventoryService, TypeOrmModule],
+})
+export class InventoryModule {}

--- a/backend/src/modules/inventory/services/inventory.service.ts
+++ b/backend/src/modules/inventory/services/inventory.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ProductStock } from '../entities/product-stock.entity';
+import { Product } from '../entities/product.entity';
+
+@Injectable()
+export class InventoryService {
+  constructor(
+    @InjectRepository(ProductStock)
+    private stockRepo: Repository<ProductStock>,
+    @InjectRepository(Product)
+    private productRepo: Repository<Product>,
+  ) {}
+
+  async adjustStock(productId: string, quantityDelta: number): Promise<void> {
+    let stock = await this.stockRepo.findOne({ where: { product: { id: productId } }, relations: ['product'] });
+    if (!stock) {
+      const product = await this.productRepo.findOne({ where: { id: productId } });
+      stock = this.stockRepo.create({ product, quantityOnHand: 0 });
+    }
+    stock.quantityOnHand += quantityDelta;
+    await this.stockRepo.save(stock);
+  }
+}

--- a/backend/src/modules/sales/entities/customer.entity.ts
+++ b/backend/src/modules/sales/entities/customer.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity('customers', { schema: 'sales' })
+export class Customer {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 100 })
+  name: string;
+}

--- a/backend/src/modules/sales/entities/invoice-line.entity.ts
+++ b/backend/src/modules/sales/entities/invoice-line.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Invoice } from './invoice.entity';
+import { Product } from '../../inventory/entities/product.entity';
+
+@Entity('invoice_lines', { schema: 'sales' })
+export class InvoiceLine {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Invoice, invoice => invoice.lines)
+  @JoinColumn({ name: 'invoice_id' })
+  invoice: Invoice;
+
+  @ManyToOne(() => Product)
+  @JoinColumn({ name: 'product_id' })
+  product: Product;
+
+  @Column('decimal', { precision: 19, scale: 4 })
+  quantity: number;
+
+  @Column('decimal', { precision: 19, scale: 4 })
+  unitPrice: number;
+
+  @Column('decimal', { precision: 19, scale: 4 })
+  lineTotal: number;
+}

--- a/backend/src/modules/sales/entities/invoice.entity.ts
+++ b/backend/src/modules/sales/entities/invoice.entity.ts
@@ -1,0 +1,36 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, JoinColumn, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+import { Company } from '../../core/entities/company.entity';
+import { Customer } from '../../sales/entities/customer.entity';
+import { InvoiceLine } from './invoice-line.entity';
+
+@Entity('invoices', { schema: 'sales' })
+export class Invoice {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Company)
+  @JoinColumn({ name: 'company_id' })
+  company: Company;
+
+  @Column({ name: 'invoice_number', length: 20 })
+  invoiceNumber: string;
+
+  @ManyToOne(() => Customer, { nullable: true })
+  @JoinColumn({ name: 'customer_id' })
+  customer?: Customer;
+
+  @Column({ name: 'invoice_date', type: 'date' })
+  invoiceDate: string;
+
+  @Column({ type: 'decimal', precision: 19, scale: 4, default: 0 })
+  total: number;
+
+  @OneToMany(() => InvoiceLine, line => line.invoice, { cascade: true })
+  lines: InvoiceLine[];
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamp' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamp' })
+  updatedAt: Date;
+}

--- a/backend/src/modules/sales/sales.module.ts
+++ b/backend/src/modules/sales/sales.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Invoice } from './entities/invoice.entity';
+import { InvoiceLine } from './entities/invoice-line.entity';
+import { Customer } from './entities/customer.entity';
+import { InvoicesService } from './services/invoices.service';
+import { PdfService } from './services/pdf.service';
+import { InventoryModule } from '../inventory/inventory.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Invoice, InvoiceLine, Customer]), InventoryModule],
+  providers: [InvoicesService, PdfService],
+  exports: [InvoicesService],
+})
+export class SalesModule {}

--- a/backend/src/modules/sales/services/invoices.service.ts
+++ b/backend/src/modules/sales/services/invoices.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Invoice } from '../entities/invoice.entity';
+import { InventoryService } from '../../inventory/services/inventory.service';
+import { PdfService } from './pdf.service';
+
+@Injectable()
+export class InvoicesService {
+  constructor(
+    @InjectRepository(Invoice)
+    private invoiceRepo: Repository<Invoice>,
+    private inventoryService: InventoryService,
+    private pdfService: PdfService,
+  ) {}
+
+  async create(invoice: Invoice): Promise<Invoice> {
+    const saved = await this.invoiceRepo.save(invoice);
+    if (invoice.lines) {
+      for (const line of invoice.lines) {
+        await this.inventoryService.adjustStock(line.product.id, -Number(line.quantity));
+      }
+    }
+    return saved;
+  }
+
+  generatePdf(invoice: Invoice): Buffer {
+    const docDefinition = {
+      content: [
+        { text: 'Factura #' + invoice.invoiceNumber, style: 'header' },
+        { text: 'Cliente: ' + (invoice.customer?.name || ''), margin: [0, 10, 0, 10] },
+        {
+          table: {
+            widths: ['*', 'auto', 'auto', 'auto'],
+            body: [
+              ['Producto', 'Cantidad', 'Precio', 'Total'],
+              ...invoice.lines.map((l) => [l.product.name, l.quantity, l.unitPrice, l.lineTotal]),
+            ],
+          },
+        },
+        { text: 'Total: ' + invoice.total, alignment: 'right', margin: [0, 10, 0, 0] },
+      ],
+    } as any;
+    return this.pdfService.generate(docDefinition);
+  }
+}

--- a/backend/src/modules/sales/services/pdf.service.ts
+++ b/backend/src/modules/sales/services/pdf.service.ts
@@ -1,0 +1,22 @@
+import PdfPrinter from 'pdfmake';
+import { TDocumentDefinitions } from 'pdfmake/interfaces';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PdfService {
+  private fonts = {
+    Roboto: {
+      normal: 'node_modules/pdfmake/fonts/Roboto-Regular.ttf',
+      bold: 'node_modules/pdfmake/fonts/Roboto-Medium.ttf',
+    },
+  };
+
+  generate(docDefinition: TDocumentDefinitions): Buffer {
+    const printer = new PdfPrinter(this.fonts);
+    const pdfDoc = printer.createPdfKitDocument(docDefinition);
+    const chunks: Buffer[] = [];
+    pdfDoc.on('data', chunk => chunks.push(chunk));
+    pdfDoc.end();
+    return Buffer.concat(chunks);
+  }
+}

--- a/docs/implementation/sales_inventory_flow.md
+++ b/docs/implementation/sales_inventory_flow.md
@@ -1,0 +1,11 @@
+# Flujo básico de facturación e inventario
+
+## Facturación
+1. Un usuario crea una factura desde el módulo de ventas.
+2. Cada línea de la factura se guarda y reduce la existencia del producto correspondiente.
+3. Al finalizar se puede generar un PDF de la factura usando `pdfmake`.
+
+## Inventario
+1. El servicio de inventario mantiene la cantidad disponible de cada producto.
+2. Cuando una factura se registra, el servicio descuenta la cantidad vendida.
+3. Otros módulos pueden llamar a `adjustStock` para ingresar o retirar unidades.


### PR DESCRIPTION
## Summary
- implement basic Inventory and Sales modules
- connect modules in app module
- add pdfmake dependency
- document invoice and inventory flows

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420bfa2600832b87c4e17e9cd6bc09