### PR TITLE
Hash user passwords before storing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 POSTGRES_PASSWORD=your_db_password
 DB_PASSWORD=your_db_password
 JWT_SECRET=your_jwt_secret
+BCRYPT_SALT_ROUNDS=10

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,7 +27,8 @@
         "rxjs": "^7.2.0",
         "send": "^0.19.1",
         "serve-static": "^1.16.2",
-        "typeorm": "^0.3.24"
+        "typeorm": "^0.3.24",
+        "bcrypt": "^5.1.0"
       },
       "devDependencies": {
         "@nestjs/cli": "^11.0.7",
@@ -52,6 +53,7 @@
         "ts-node": "^10.0.0",
         "tsconfig-paths": "^3.10.1",
         "typescript": "^4.3.5",
+        "@types/bcrypt": "^5.0.0",
         "webpack": "^5.99.8",
         "webpack-cli": "^6.0.1"
       }

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,7 +40,8 @@
     "send": "^0.19.1",
     "serve-static": "^1.16.2",
     "typeorm": "^0.3.24",
-    "pdfmake": "^0.2.7"
+    "pdfmake": "^0.2.7",
+    "bcrypt": "^5.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.7",
@@ -65,6 +66,7 @@
     "ts-node": "^10.0.0",
     "tsconfig-paths": "^3.10.1",
     "typescript": "^4.3.5",
+    "@types/bcrypt": "^5.0.0",
     "webpack": "^5.99.8",
     "webpack-cli": "^6.0.1"
   },

--- a/backend/src/modules/users/services/users.service.ts
+++ b/backend/src/modules/users/services/users.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as bcrypt from 'bcrypt';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../entities/user.entity';
@@ -10,13 +12,23 @@ export class UsersService {
   constructor(
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
+    private readonly configService: ConfigService,
   ) {}
 
-  create(dto: CreateUserDto) {
+  private get saltRounds(): number {
+    const rounds = parseInt(
+      this.configService.get<string>('BCRYPT_SALT_ROUNDS') ?? '10',
+      10,
+    );
+    return Number.isNaN(rounds) ? 10 : rounds;
+  }
+
+  async create(dto: CreateUserDto) {
+    const passwordHash = await bcrypt.hash(dto.password, this.saltRounds);
     const user = this.usersRepository.create({
       username: dto.username,
       email: dto.email,
-      passwordHash: dto.password,
+      passwordHash,
       firstName: dto.firstName,
       lastName: dto.lastName,
       isAdmin: dto.isAdmin ?? false,
@@ -34,9 +46,10 @@ export class UsersService {
 
   async update(id: string, dto: UpdateUserDto) {
     if (dto.password) {
+      const passwordHash = await bcrypt.hash(dto.password, this.saltRounds);
       await this.usersRepository.update(id, {
         ...dto,
-        passwordHash: dto.password,
+        passwordHash,
       });
     } else {
       await this.usersRepository.update(id, dto as any);


### PR DESCRIPTION
## Summary
- add bcrypt dependency
- hash passwords using bcrypt on user create and update
- configure salt rounds via `BCRYPT_SALT_ROUNDS`
- document bcrypt env var in example

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842181c9040832b93433238e3c334d8