### PR TITLE
Add Jest config and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ This command builds the containers and starts them on their default ports
    npm run start:dev
    ```
 
+### Running tests
+
+Unit tests live in `backend/src` and can be executed with:
+
+```bash
+cd backend
+npm run test
+```
+
 ### Frontend
 
 The frontend has its own README with detailed commands.  In short:

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+};
+
+export default config;

--- a/backend/package.json
+++ b/backend/package.json
@@ -67,22 +67,5 @@
     "typescript": "^4.3.5",
     "webpack": "^5.99.8",
     "webpack-cli": "^6.0.1"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/backend/src/modules/users/services/users.service.spec.ts
+++ b/backend/src/modules/users/services/users.service.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { UsersService } from './users.service';
+import { User } from '../entities/user.entity';
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let repo: Repository<User>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        { provide: getRepositoryToken(User), useClass: Repository },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    repo = module.get<Repository<User>>(getRepositoryToken(User));
+  });
+
+  it('should create a user', async () => {
+    const dto = { username: 'u', email: 'e', password: 'p' } as any;
+    const entity = { id: '1' } as User;
+    jest.spyOn(repo, 'create').mockReturnValue(entity);
+    jest.spyOn(repo, 'save').mockResolvedValue(entity);
+
+    const result = await service.create(dto);
+
+    expect(repo.create).toHaveBeenCalledWith({
+      username: 'u',
+      email: 'e',
+      passwordHash: 'p',
+      firstName: undefined,
+      lastName: undefined,
+      isAdmin: false,
+    });
+    expect(repo.save).toHaveBeenCalledWith(entity);
+    expect(result).toBe(entity);
+  });
+
+  it('should find all', async () => {
+    const data = [{} as User];
+    jest.spyOn(repo, 'find').mockResolvedValue(data);
+    expect(await service.findAll()).toBe(data);
+  });
+});

--- a/docs/architecture/backend_architecture.md
+++ b/docs/architecture/backend_architecture.md
@@ -11,4 +11,6 @@ The backend is built with [NestJS](https://nestjs.com/) and TypeScript. It follo
   - `common/` – shared DTOs and utilities
 - `test/` – unit and e2e tests
 
+Run `npm run test` inside `backend/` to execute the Jest unit tests.
+
 The entry point is `main.ts` and `app.module.ts` brings the modules together. `docker-compose.yml` runs the service as `backend` and connects to the PostgreSQL container.


### PR DESCRIPTION
## Summary
- move Jest options to `backend/jest.config.ts`
- add unit tests for `UsersService`
- document running tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684218208544832baf156f31f35af21c