### PR TITLE
Add i18n support to backend and frontend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -40,7 +40,8 @@
     "send": "^0.19.1",
     "serve-static": "^1.16.2",
     "typeorm": "^0.3.24",
-    "pdfmake": "^0.2.7"
+    "pdfmake": "^0.2.7",
+    "@nestjs/i18n": "^3.1.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^11.0.7",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -2,6 +2,10 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import configuration from './config/configuration';
 import { APP_INTERCEPTOR } from '@nestjs/core';
+import { I18nModule, I18nJsonParser, QueryResolver, AcceptLanguageResolver } from '@nestjs/i18n';
+import { join } from 'path';
+
+import { HelloController } from './hello.controller';
 
 // Interceptor
 import { AuditInterceptor } from './common/interceptors/audit.interceptor';
@@ -18,6 +22,19 @@ import { SalesModule } from './modules/sales/sales.module';
   imports: [
     // Configuración global y carga de variables desde .env
     ConfigModule.forRoot({ isGlobal: true, load: [configuration] }),
+
+    I18nModule.forRoot({
+      fallbackLanguage: 'en',
+      parser: I18nJsonParser,
+      parserOptions: {
+        path: join(__dirname, '/i18n/'),
+        watch: false,
+      },
+      resolvers: [
+        { use: QueryResolver, options: ['lang'] },
+        AcceptLanguageResolver,
+      ],
+    }),
 
     // Configuración asíncrona de TypeORM utilizando ConfigService
     TypeOrmModule.forRootAsync({
@@ -44,6 +61,7 @@ import { SalesModule } from './modules/sales/sales.module';
     InventoryModule,
     SalesModule,
   ],
+  controllers: [HelloController],
   providers: [
     {
       provide: APP_INTERCEPTOR,

--- a/backend/src/hello.controller.ts
+++ b/backend/src/hello.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get } from '@nestjs/common';
+import { I18n, I18nContext } from 'nestjs-i18n';
+
+@Controller()
+export class HelloController {
+  @Get('hello')
+  hello(@I18n() i18n: I18nContext) {
+    return { message: i18n.t('common.HELLO_MESSAGE') };
+  }
+}

--- a/backend/src/i18n/en/common.json
+++ b/backend/src/i18n/en/common.json
@@ -1,0 +1,3 @@
+{
+  "HELLO_MESSAGE": "Hello world!"
+}

--- a/backend/src/i18n/es/common.json
+++ b/backend/src/i18n/es/common.json
@@ -1,0 +1,3 @@
+{
+  "HELLO_MESSAGE": "\u00a1Hola mundo!"
+}

--- a/frontend/edi-frontend/package.json
+++ b/frontend/edi-frontend/package.json
@@ -20,7 +20,8 @@
     "pinia": "^3.0.2",
     "quasar": "^2.16.0",
     "vue": "^3.4.18",
-    "vue-router": "^4.0.12"
+    "vue-router": "^4.0.12",
+    "vue-i18n": "^9.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",

--- a/frontend/edi-frontend/quasar.config.ts
+++ b/frontend/edi-frontend/quasar.config.ts
@@ -13,8 +13,9 @@ export default defineConfig((/* ctx */) => {
     // https://v2.quasar.dev/quasar-cli-vite/boot-files
     boot: [
       'axios',
-      'pinia'
-       
+      'pinia',
+      'i18n'
+
     ],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#css

--- a/frontend/edi-frontend/src/boot/i18n.ts
+++ b/frontend/edi-frontend/src/boot/i18n.ts
@@ -1,0 +1,14 @@
+import { boot } from 'quasar/wrappers';
+import { createI18n } from 'vue-i18n';
+import messages from 'src/i18n';
+
+export const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages,
+});
+
+export default boot(({ app }) => {
+  app.use(i18n);
+});

--- a/frontend/edi-frontend/src/i18n/en.ts
+++ b/frontend/edi-frontend/src/i18n/en.ts
@@ -1,0 +1,7 @@
+export default {
+  hello: 'Hello world!',
+  login: {
+    button: 'Login',
+    userLabel: 'User:'
+  }
+};

--- a/frontend/edi-frontend/src/i18n/es.ts
+++ b/frontend/edi-frontend/src/i18n/es.ts
@@ -1,0 +1,7 @@
+export default {
+  hello: '¡Hola mundo!',
+  login: {
+    button: 'Iniciar sesión',
+    userLabel: 'Usuario:'
+  }
+};

--- a/frontend/edi-frontend/src/i18n/index.ts
+++ b/frontend/edi-frontend/src/i18n/index.ts
@@ -1,0 +1,7 @@
+import en from './en';
+import es from './es';
+
+export default {
+  en,
+  es,
+};

--- a/frontend/edi-frontend/src/pages/IndexPage.vue
+++ b/frontend/edi-frontend/src/pages/IndexPage.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page class="row items-center justify-evenly">
+    <p>{{ t('hello') }}</p>
     <example-component
       title="Example component"
       active
@@ -11,8 +12,11 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import type { Todo, Meta } from 'components/models';
 import ExampleComponent from 'components/ExampleComponent.vue';
+
+const { t } = useI18n();
 
 const todos = ref<Todo[]>([
   {

--- a/frontend/edi-frontend/src/pages/Login.vue
+++ b/frontend/edi-frontend/src/pages/Login.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { useAuthStore } from 'src/stores/auth';
+import { useI18n } from 'vue-i18n';
 const auth = useAuthStore();
+const { t } = useI18n();
 
 function handleLogin() {
   // Aquí simulas la respuesta del backend con usuario y token
@@ -14,8 +16,8 @@ function handleLogin() {
 
 <template>
   <div>
-    <button @click="handleLogin">Login Simulado</button>
-    <p v-if="auth.isLoggedIn">Usuario: {{ auth.user?.username }}</p>
+    <button @click="handleLogin">{{ t('login.button') }}</button>
+    <p v-if="auth.isLoggedIn">{{ t('login.userLabel') }} {{ auth.user?.username }}</p>
   </div>
 </template>
 

--- a/frontend/edi-frontend/tsconfig.json
+++ b/frontend/edi-frontend/tsconfig.json
@@ -16,7 +16,8 @@
       "boot/*": ["src/boot/*"],
       "layouts/*": ["src/layouts/*"],
       "pages/*": ["src/pages/*"],
-      "stores/*": ["src/stores/*"]
+      "stores/*": ["src/stores/*"],
+      "i18n/*": ["src/i18n/*"]
     },
     "types": ["vite/client", "node"]
   },


### PR DESCRIPTION
## Summary
- add `@nestjs/i18n` and example HelloController on backend
- provide English and Spanish translations for backend
- install `vue-i18n` and Quasar boot file
- provide English and Spanish translations on frontend
- show translations on login page and index page

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend/edi-frontend`

------
https://chatgpt.com/codex/tasks/task_e_6842182345d0832b97272f5724907aa4