### PR TITLE
Fix backend linting config

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: './tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'prettier',
+  ],
+  env: {
+    node: true,
+    es2021: true,
+    jest: true,
+  },
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
+};


### PR DESCRIPTION
## Summary
- add a NestJS ESLint configuration file in the backend

## Testing
- `npm run lint` *(fails: ESLint not installed)*
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68421b87b400832b95ba7963f2140648